### PR TITLE
fix: refactor to "reporting-format-template-repo"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository content is license for use under the [CC BY 4.0 license](https:/
 
 ## Funding and acknowledgments
 
-*Customize funding statement below. The general statement provided covers funding mechanism for community reporting formats*  
+*Customize funding statement below. The general statement provided covers funding mechanism for reporting formats*  
 
 Funding for the development of ESS-DIVE's [add your reporting format name here] reporting format was provided by the U.S. Department of Energy, Office of Science, Office of Biological and Environmental Research, Climate and Environmental Science Division, Data Management program under contract number DE-AC02-05CH11231.
 


### PR DESCRIPTION
Edit made to `reporting-format-template-repo` repository based on March 2025 refactor of all repos within the ESS-DIVE Workspace GitHub.

As this repository will not be versioned, a release and tag will not be created for this repository.

Changes were made to the following file(s):
- README.md